### PR TITLE
termbarc.c: initialize freq and temp variables to zero

### DIFF
--- a/termbarc.c
+++ b/termbarc.c
@@ -286,7 +286,7 @@ unsigned long long update_mem()
 
 void update_cpu_base_speed()
 {
-        int temp;
+        int temp = 0;
         size_t templen = sizeof(temp);
 
         int mib[5] = { CTL_HW, HW_CPUSPEED };
@@ -300,7 +300,7 @@ void update_cpu_base_speed()
 
 void update_cpu_avg_speed()
 {
-        uint64_t freq;
+        uint64_t freq = 0;
         size_t len = sizeof(freq);
         int mib[2] = { CTL_HW, HW_CPUSPEED };
 


### PR DESCRIPTION
As both of these values are un-initialized, compiling the program with -O0 (no preferable compiler optimizations), would yield random values, similar to the image. Initializing them to zero, avoids this problem.

![image](https://github.com/gonzalo-/termbarc/assets/71683721/f8137108-d8ca-418c-8406-8e511f537abf)
